### PR TITLE
修复港股成交额数据的解析

### DIFF
--- a/pytdx/parser/ex_get_instrument_bars.py
+++ b/pytdx/parser/ex_get_instrument_bars.py
@@ -63,14 +63,14 @@ class GetInstrumentBars(BaseParser):
 
         for i in range(ret_count):
             year, month, day, hour, minute, pos = get_datetime(self.category, body_buf, pos)
-            (open_price, high, low, close, position, trade, price) = struct.unpack("<ffffIIf", body_buf[pos: pos+28])
+            (open_price, high, low, close, amount, trade, price) = struct.unpack("<fffffIf", body_buf[pos: pos+28])
             pos += 28
             kline = OrderedDict([
                 ("open", open_price),
                 ("high", high),
                 ("low", low),
                 ("close", close),
-                ("position", position),
+                ("amount", amount),
                 ("trade", trade),
                 ("price", price),
                 ("year", year),

--- a/pytdx/reader/exhq_daily_bar_reader.py
+++ b/pytdx/reader/exhq_daily_bar_reader.py
@@ -25,7 +25,7 @@ class TdxExHqDailyBarReader(BaseReader):
 
         with open(fname, 'rb') as f:
             content = f.read()
-            return self.unpack_records('<IffffIIf', content)
+            return self.unpack_records('<IfffffIf', content)
 
         return []
 
@@ -35,9 +35,9 @@ class TdxExHqDailyBarReader(BaseReader):
         # 只传入了一个参数
         data = [self._df_convert(row) for row in self.parse_data_by_file(code_or_file)]
 
-        df =  pd.DataFrame(data=data, columns=('date', 'open', 'high', 'low', 'close', 'amount', 'volume','jiesuan'))
+        df =  pd.DataFrame(data=data, columns=('date', 'open', 'high', 'low', 'close', 'amount', 'volume', 'jiesuan'))
         df.index = pd.to_datetime(df.date)
-        return df[['open', 'high', 'low', 'close', 'amount', 'volume','jiesuan']]
+        return df[['open', 'high', 'low', 'close', 'amount', 'volume', 'jiesuan']]
 
     def _df_convert(self, row):
         t_date = str(row[0])


### PR DESCRIPTION
通达信港股成交额是浮点类型，修改后经过和通达信界面上的数据核对，正确无误。不知道这个修改是否会影响其他外盘数据的解析？如果其他数据是用的整数成交量，那还得分开判断。
另外，“jiesuan” 这个字段是干什么的？