### PR TITLE
连接池获取重连获取结果返回

### DIFF
--- a/pytdx/pool/hqpool.py
+++ b/pytdx/pool/hqpool.py
@@ -99,7 +99,7 @@ class TdxHqPool_API(object):
                 self.hot_failover_api = None
             # 阻塞0.2秒，然后递归调用自己
             time.sleep(self.api_retry_interval)
-            self.do_hq_api_call(method_name, *args, **kwargs)
+            result = self.do_hq_api_call(method_name, *args, **kwargs)
             self.api_call_retry_times += 1
 
         else:


### PR DESCRIPTION
原来连接池的实现中，重连之后再去获取数据并不会返回重连获取成功的数据。