### PR TITLE
setattr of object instead of class

### DIFF
--- a/pytdx/async/reflection.py
+++ b/pytdx/async/reflection.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 import six
+from functools import partial
 
 if six.PY2:
     raise NotImplementedError("I am only working for Python3")
@@ -69,10 +70,12 @@ def make_async_parser(parser, connection):
 
             return self.parseResponse(body_buf)
 
-    setattr(parser, "call_api", call_api)
-    setattr(parser, "_call_api", _call_api)
+    cmd = parser(None, None)
 
-    return parser(None, None)
+    setattr(cmd, "call_api", partial(call_api,cmd))
+    setattr(cmd, "_call_api", partial(_call_api, cmd))
+
+    return cmd
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
在使用反射的时候，修改object的方法而不是class的方法。如果使用修改class的方案，会导致async版本接口和普通接口无法混合使用，因为在async里面已经把class改了，普通接口就无法使用了。