### PR TITLE
bugfix: get_event_loop() --> new_event_loop()

### DIFF
--- a/pytdx/async/pool.py
+++ b/pytdx/async/pool.py
@@ -13,7 +13,7 @@ class ConnectionPool(object):
         self.pid = os.getpid()
         self.max_connections = max_connections
 
-        self.loop = loop or asyncio.get_event_loop()
+        self.loop = loop or asyncio.new_event_loop()
         self.ip = ip
         self.port = port
         self._available_connections = []


### PR DESCRIPTION
get_event_loop只能在主线程中调用，在使用了多线程（例如logbook等库）的程序中，非主线程调用会报错：
![jo q9 zth2nzx 7ss 09](https://user-images.githubusercontent.com/6207775/34596216-e5021b2c-f218-11e7-868c-0e3d27dcd971.png)
