### PR TITLE
修复local variable 'nature_name' referenced before assignment

### DIFF
--- a/pytdx/parser/ex_get_history_transaction_data.py
+++ b/pytdx/parser/ex_get_history_transaction_data.py
@@ -40,6 +40,7 @@ class GetHistoryTransactionData(BaseParser):
             second = direction % 10000
             nature = direction #### 为了老用户接口的兼容性，已经转换为使用 nature_value
             value = direction // 10000
+            nature_name = '换手'
             # 对于大于59秒的值，属于无效数值
             if second > 59:
                 second = 0


### PR DESCRIPTION
测试用例：`get_history_transaction_data(47, 'IFL3', 0, 1800, '20200120')`
原因：`value = 2`，`volume = 1`，`zengcang = -18906`，没有if分支可以匹配上
按代码上下文意思，一开始就给赋上“换手”，以免出现`nature_name`未定义