### PR TITLE
bug fix: 如果日线数据中某个日期格式出错会抛异常，后面所有数据即使格式正确也无法解释出来。

### DIFF
--- a/pytdx/reader/daily_bar_reader.py
+++ b/pytdx/reader/daily_bar_reader.py
@@ -65,7 +65,7 @@ class TdxDailyBarReader(BaseReader):
         data = [self._df_convert(row, coefficient) for row in self.parse_data_by_file(fname)]
 
         df = pd.DataFrame(data=data, columns=('date', 'open', 'high', 'low', 'close', 'amount', 'volume'))
-        df.index = pd.to_datetime(df.date)
+        df.index = pd.to_datetime(df.date, errors='coerce')
         return df[['open', 'high', 'low', 'close', 'amount', 'volume']]
 
     def get_df_by_code(self, code, exchange):


### PR DESCRIPTION
通达信某些日数据日期格式有问题，会导致该个股所有日线数据解释失败。
解决方案：在解释日期时出错则设为NaT，然后继续解释。返回的DataFrame中根据实际情况dropna。